### PR TITLE
Update `pyspark` to version `3.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
     - 0001-Disable-symlinks-on-Windows.patch
 
 build:
-  skip: True  # [py<36]
+  # the s390x platform is not supported at this time
+  skip: True  # [py<36 or s390x]
   noarch: python
   number: 0
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyspark" %}
-{% set version = "3.1.2" %}
+{% set version = "3.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5e25ebb18756e9715f4d26848cc7e558035025da74b4fc325a0ebc05ff538e65
+  sha256: bfea06179edbfb4bc76a0f470bd3c38e12f00e1023e3ad0373558d07cff102ab
   patches:
     - 0001-Disable-symlinks-on-Windows.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
   commands:
     - bash -c "compgen -c spark && compgen -c pyspark"  # [not win]
     - where *spark*                                     # [win]
+    - pip check
   imports:
     - pyspark
     - pyspark.ml
@@ -48,6 +49,8 @@ test:
     - pyspark.mllib.stat
     - pyspark.sql
     - pyspark.streaming
+  requires:
+    - pip
 
 about:
   home: https://spark.apache.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   # the s390x platform is not supported at this time
-  skip: True  # [py<36 or s390x]
+  skip: True  # [s390x]
   noarch: python
   number: 0
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
@@ -33,7 +33,7 @@ requirements:
     - pandas >=0.23.2
     - py4j ==0.10.9.2
     - pyarrow >=1.0.0
-    - python
+    - python >=3.6
 
 test:
   commands:
@@ -52,6 +52,7 @@ test:
     - pyspark.streaming
   requires:
     - pip
+    - python <3.10
 
 about:
   home: https://spark.apache.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - pyspark.streaming
 
 about:
-  home: http://spark.apache.org/
+  home: https://spark.apache.org/
   license: Apache-2.0
   license_family: Apache
   # Not yet available in the pypi release


### PR DESCRIPTION
  `pyspark` version `3.2.0`
1.  - [X] check the upstream 
    https://github.com/apache/spark/tree/v3.2.0/python

2. - [X] check the pinnings 
    https://github.com/apache/spark/blob/v3.2.0/python/setup.py

    https://github.com/apache/spark/blob/v3.2.0/python/setup.cfg

    https://github.com/apache/spark/blob/v3.2.0/python/MANIFEST.in

    - minimal version of `python` supported is `python 3.6`

    https://github.com/apache/spark/blob/v3.2.0/python/setup.py#L275

    - Python pinnings were added in this commit

    https://github.com/AnacondaRecipes/pyspark-feedstock/commit/483b412f56e0fd73943f1308acb48d031a3e0874

3.  - [X] check the changelogs 
    - changelogs were not available in the upstream, instead the new changes were included in the documentation. 

    https://spark.apache.org/releases/spark-release-3-2-0.html

4.  - [X] additional research
    https://github.com/conda-forge/pyspark-feedstock/issues

    There were two open issues at the time of the review

    one is a feature request to add configuration properties for `log4j`

    https://github.com/conda-forge/pyspark-feedstock/issues/7

    The other issue is also a feature request to add support for version `v2.4.7`

    https://github.com/conda-forge/pyspark-feedstock/issues/29

5.  - [X] verify dev_url 
    https://github.com/apache/spark/tree/master/python

6.  - [X] verify doc_url
    https://spark.apache.org/documentation.html

7.  - [X] license is spdx compliant 
   - Apache-2.0

   https://spdx.org/licenses/Apache-2.0.html

8.  - [X] license family
   - Apache

9. - [X] verify the build number
   - build number is set to zero
10.  - [X] verify setuptools 
   - `setuptools` is included in the recipe
11.  - [X] verify wheel 
   - `wheel` is included in the recipe
12.  - [X] pip in the test section 
   - added `pip` to the test section
13.  - [X] veriy the test section 
   - the test section was verified

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `pyspark` to version `3.2.0`