### PR TITLE
pyspark 3.2.1

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -200,232 +200,35 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
+
 ------------------------------------------------------------------------------------
-This project bundles some components that are also licensed under the Apache
-License Version 2.0:
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See licenses/
+for text of these licenses.
 
-commons-beanutils:commons-beanutils
-org.apache.zookeeper:zookeeper
-oro:oro
-commons-configuration:commons-configuration
-commons-digester:commons-digester
-com.chuusai:shapeless_2.11
-com.googlecode.javaewah:JavaEWAH
-com.twitter:chill-java
-com.twitter:chill_2.11
-com.univocity:univocity-parsers
-javax.jdo:jdo-api
-joda-time:joda-time
-net.sf.opencsv:opencsv
-org.apache.derby:derby
-org.objenesis:objenesis
-org.roaringbitmap:RoaringBitmap
-org.scalanlp:breeze-macros_2.11
-org.scalanlp:breeze_2.11
-org.typelevel:macro-compat_2.11
-org.yaml:snakeyaml
-org.apache.xbean:xbean-asm5-shaded
-com.squareup.okhttp3:logging-interceptor
-com.squareup.okhttp3:okhttp
-com.squareup.okio:okio
-org.apache.spark:spark-catalyst_2.11
-org.apache.spark:spark-kvstore_2.11
-org.apache.spark:spark-launcher_2.11
-org.apache.spark:spark-mllib-local_2.11
-org.apache.spark:spark-network-common_2.11
-org.apache.spark:spark-network-shuffle_2.11
-org.apache.spark:spark-sketch_2.11
-org.apache.spark:spark-tags_2.11
-org.apache.spark:spark-unsafe_2.11
-commons-httpclient:commons-httpclient
-com.vlkan:flatbuffers
-com.ning:compress-lzf
-io.airlift:aircompressor
-io.dropwizard.metrics:metrics-core
-io.dropwizard.metrics:metrics-ganglia
-io.dropwizard.metrics:metrics-graphite
-io.dropwizard.metrics:metrics-json
-io.dropwizard.metrics:metrics-jvm
-org.iq80.snappy:snappy
-com.clearspring.analytics:stream
-com.jamesmurty.utils:java-xmlbuilder
-commons-codec:commons-codec
-commons-collections:commons-collections
-io.fabric8:kubernetes-client
-io.fabric8:kubernetes-model
-io.netty:netty
-io.netty:netty-all
-net.hydromatic:eigenbase-properties
-net.sf.supercsv:super-csv
-org.apache.arrow:arrow-format
-org.apache.arrow:arrow-memory
-org.apache.arrow:arrow-vector
-org.apache.calcite:calcite-avatica
-org.apache.calcite:calcite-core
-org.apache.calcite:calcite-linq4j
-org.apache.commons:commons-crypto
-org.apache.commons:commons-lang3
-org.apache.hadoop:hadoop-annotations
-org.apache.hadoop:hadoop-auth
-org.apache.hadoop:hadoop-client
-org.apache.hadoop:hadoop-common
-org.apache.hadoop:hadoop-hdfs
-org.apache.hadoop:hadoop-mapreduce-client-app
-org.apache.hadoop:hadoop-mapreduce-client-common
-org.apache.hadoop:hadoop-mapreduce-client-core
-org.apache.hadoop:hadoop-mapreduce-client-jobclient
-org.apache.hadoop:hadoop-mapreduce-client-shuffle
-org.apache.hadoop:hadoop-yarn-api
-org.apache.hadoop:hadoop-yarn-client
-org.apache.hadoop:hadoop-yarn-common
-org.apache.hadoop:hadoop-yarn-server-common
-org.apache.hadoop:hadoop-yarn-server-web-proxy
-org.apache.httpcomponents:httpclient
-org.apache.httpcomponents:httpcore
-org.apache.orc:orc-core
-org.apache.orc:orc-mapreduce
-org.mortbay.jetty:jetty
-org.mortbay.jetty:jetty-util
-com.jolbox:bonecp
-org.json4s:json4s-ast_2.11
-org.json4s:json4s-core_2.11
-org.json4s:json4s-jackson_2.11
-org.json4s:json4s-scalap_2.11
-com.carrotsearch:hppc
-com.fasterxml.jackson.core:jackson-annotations
-com.fasterxml.jackson.core:jackson-core
-com.fasterxml.jackson.core:jackson-databind
-com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations
-com.fasterxml.jackson.module:jackson-module-paranamer
-com.fasterxml.jackson.module:jackson-module-scala_2.11
-com.github.mifmif:generex
-com.google.code.findbugs:jsr305
-com.google.code.gson:gson
-com.google.inject:guice
-com.google.inject.extensions:guice-servlet
-com.twitter:parquet-hadoop-bundle
-commons-beanutils:commons-beanutils-core
-commons-cli:commons-cli
-commons-dbcp:commons-dbcp
-commons-io:commons-io
-commons-lang:commons-lang
-commons-logging:commons-logging
-commons-net:commons-net
-commons-pool:commons-pool
-io.fabric8:zjsonpatch
-javax.inject:javax.inject
-javax.validation:validation-api
-log4j:apache-log4j-extras
-log4j:log4j
-net.sf.jpam:jpam
-org.apache.avro:avro
-org.apache.avro:avro-ipc
-org.apache.avro:avro-mapred
-org.apache.commons:commons-compress
-org.apache.commons:commons-math3
-org.apache.curator:curator-client
-org.apache.curator:curator-framework
-org.apache.curator:curator-recipes
-org.apache.directory.api:api-asn1-api
-org.apache.directory.api:api-util
-org.apache.directory.server:apacheds-i18n
-org.apache.directory.server:apacheds-kerberos-codec
-org.apache.htrace:htrace-core
-org.apache.ivy:ivy
-org.apache.mesos:mesos
-org.apache.parquet:parquet-column
-org.apache.parquet:parquet-common
-org.apache.parquet:parquet-encoding
-org.apache.parquet:parquet-format
-org.apache.parquet:parquet-hadoop
-org.apache.parquet:parquet-jackson
-org.apache.thrift:libfb303
-org.apache.thrift:libthrift
-org.codehaus.jackson:jackson-core-asl
-org.codehaus.jackson:jackson-mapper-asl
-org.datanucleus:datanucleus-api-jdo
-org.datanucleus:datanucleus-core
-org.datanucleus:datanucleus-rdbms
-org.lz4:lz4-java
-org.spark-project.hive:hive-beeline
-org.spark-project.hive:hive-cli
-org.spark-project.hive:hive-exec
-org.spark-project.hive:hive-jdbc
-org.spark-project.hive:hive-metastore
-org.xerial.snappy:snappy-java
-stax:stax-api
-xerces:xercesImpl
-org.codehaus.jackson:jackson-jaxrs
-org.codehaus.jackson:jackson-xc
-org.eclipse.jetty:jetty-client
-org.eclipse.jetty:jetty-continuation
-org.eclipse.jetty:jetty-http
-org.eclipse.jetty:jetty-io
-org.eclipse.jetty:jetty-jndi
-org.eclipse.jetty:jetty-plus
-org.eclipse.jetty:jetty-proxy
-org.eclipse.jetty:jetty-security
-org.eclipse.jetty:jetty-server
-org.eclipse.jetty:jetty-servlet
-org.eclipse.jetty:jetty-servlets
-org.eclipse.jetty:jetty-util
-org.eclipse.jetty:jetty-webapp
-org.eclipse.jetty:jetty-xml
 
+Apache Software Foundation License 2.0
+--------------------------------------
+
+common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
 core/src/main/java/org/apache/spark/util/collection/TimSort.java
 core/src/main/resources/org/apache/spark/ui/static/bootstrap*
 core/src/main/resources/org/apache/spark/ui/static/jsonFormatter*
 core/src/main/resources/org/apache/spark/ui/static/vis*
 docs/js/vendor/bootstrap.js
+external/spark-ganglia-lgpl/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
 
 
-------------------------------------------------------------------------------------
-This product bundles various third-party components under other open source licenses.
-This section summarizes those components and their licenses. See licenses-binary/
-for text of these licenses.
+Python Software Foundation License
+----------------------------------
 
-
-BSD 2-Clause
-------------
-
-com.github.luben:zstd-jni
-javolution:javolution
-com.esotericsoftware:kryo-shaded
-com.esotericsoftware:minlog
-com.esotericsoftware:reflectasm
-com.google.protobuf:protobuf-java
-org.codehaus.janino:commons-compiler
-org.codehaus.janino:janino
-jline:jline
-org.jodd:jodd-core
-
+python/docs/source/_static/copybutton.js
 
 BSD 3-Clause
 ------------
 
-dk.brics.automaton:automaton
-org.antlr:antlr-runtime
-org.antlr:ST4
-org.antlr:stringtemplate
-org.antlr:antlr4-runtime
-antlr:antlr
-com.github.fommil.netlib:core
-com.thoughtworks.paranamer:paranamer
-org.scala-lang:scala-compiler
-org.scala-lang:scala-library
-org.scala-lang:scala-reflect
-org.scala-lang.modules:scala-parser-combinators_2.11
-org.scala-lang.modules:scala-xml_2.11
-org.fusesource.leveldbjni:leveldbjni-all
-net.sourceforge.f2j:arpack_combined_all
-xmlenc:xmlenc
-net.sf.py4j:py4j
-org.jpmml:pmml-model
-org.jpmml:pmml-schema
-
 python/lib/py4j-*-src.zip
-python/pyspark/cloudpickle.py
+python/pyspark/cloudpickle/*.py
 python/pyspark/join.py
 core/src/main/resources/org/apache/spark/ui/static/d3.min.js
 
@@ -437,74 +240,14 @@ is distributed under the 3-Clause BSD license.
 MIT License
 -----------
 
-org.spire-math:spire-macros_2.11
-org.spire-math:spire_2.11
-org.typelevel:machinist_2.11
-net.razorvine:pyrolite
-org.slf4j:jcl-over-slf4j
-org.slf4j:jul-to-slf4j
-org.slf4j:slf4j-api
-org.slf4j:slf4j-log4j12
-com.github.scopt:scopt_2.11
-
 core/src/main/resources/org/apache/spark/ui/static/dagre-d3.min.js
 core/src/main/resources/org/apache/spark/ui/static/*dataTables*
 core/src/main/resources/org/apache/spark/ui/static/graphlib-dot.min.js
-ore/src/main/resources/org/apache/spark/ui/static/jquery*
+core/src/main/resources/org/apache/spark/ui/static/jquery*
 core/src/main/resources/org/apache/spark/ui/static/sorttable.js
 docs/js/vendor/anchor.min.js
 docs/js/vendor/jquery*
 docs/js/vendor/modernizer*
-
-
-Common Development and Distribution License (CDDL) 1.0
-------------------------------------------------------
-
-javax.activation:activation  http://www.oracle.com/technetwork/java/javase/tech/index-jsp-138795.html
-javax.xml.stream:stax-api    https://jcp.org/en/jsr/detail?id=173
-
-
-Common Development and Distribution License (CDDL) 1.1
-------------------------------------------------------
-
-javax.annotation:javax.annotation-api    https://jcp.org/en/jsr/detail?id=250
-javax.servlet:javax.servlet-api   https://javaee.github.io/servlet-spec/
-javax.transaction:jta http://www.oracle.com/technetwork/java/index.html
-javax.ws.rs:javax.ws.rs-api https://github.com/jax-rs
-javax.xml.bind:jaxb-api    https://github.com/javaee/jaxb-v2
-org.glassfish.hk2:hk2-api https://github.com/javaee/glassfish
-org.glassfish.hk2:hk2-locator (same)
-org.glassfish.hk2:hk2-utils
-org.glassfish.hk2:osgi-resource-locator
-org.glassfish.hk2.external:aopalliance-repackaged
-org.glassfish.hk2.external:javax.inject
-org.glassfish.jersey.bundles.repackaged:jersey-guava
-org.glassfish.jersey.containers:jersey-container-servlet
-org.glassfish.jersey.containers:jersey-container-servlet-core
-org.glassfish.jersey.core:jersey-client
-org.glassfish.jersey.core:jersey-common
-org.glassfish.jersey.core:jersey-server
-org.glassfish.jersey.media:jersey-media-jaxb
-
-
-Mozilla Public License (MPL) 1.1
---------------------------------
-
-com.github.rwl:jtransforms https://sourceforge.net/projects/jtransforms/
-
-
-Python Software Foundation License
-----------------------------------
-
-pyspark/heapq3.py
-
-
-Public Domain
--------------
-
-aopalliance:aopalliance
-net.iharder:base64
-org.tukaani:xz
 
 
 Creative Commons CC0 1.0 Universal Public Domain Dedication

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyspark" %}
-{% set version = "3.1.2" %}
+{% set version = "3.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5e25ebb18756e9715f4d26848cc7e558035025da74b4fc325a0ebc05ff538e65
+  sha256: 0b81359262ec6e9ac78c353344e7de026027d140c6def949ff0d80ab70f89a54
   patches:
     - 0001-Disable-symlinks-on-Windows.patch
 
 build:
-  skip: True  # [py<36]
-  noarch: python
   number: 0
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   build:
-    - git
-    - patch  # [not win]
+    - patch     # [not win]
     - m2-patch  # [win]
   host:
     - pip
@@ -28,34 +26,58 @@ requirements:
     - setuptools
     - wheel
   run:
-    - numpy >=1.7
-    - pandas >=0.23.2
-    - py4j ==0.10.9.2
-    - pyarrow >=1.0.0
     - python
+    - py4j ==0.10.9.3
+    # extras_require dependencies
+    - numpy >=1.14
+    - pandas >=0.23.2
+    - pyarrow >=1.0.0
 
 test:
-  commands:
-    - bash -c "compgen -c spark && compgen -c pyspark"  # [not win]
-    - where *spark*                                     # [win]
   imports:
     - pyspark
+    - pyspark.cloudpickle
     - pyspark.ml
     - pyspark.ml.linalg
     - pyspark.ml.param
     - pyspark.mllib
     - pyspark.mllib.linalg
     - pyspark.mllib.stat
+    - pyspark.pandas
+    - pyspark.pandas.data_type_ops
+    - pyspark.pandas.indexes
+    - pyspark.pandas.missing
+    - pyspark.pandas.plot
+    - pyspark.pandas.spark
+    - pyspark.pandas.typedef
+    - pyspark.pandas.usage_logging
+    - pyspark.python.pyspark
+    - pyspark.python.lib
     - pyspark.sql
+    - pyspark.sql.avro
+    - pyspark.sql.pandas
     - pyspark.streaming
+    - pyspark.bin
+    - pyspark.sbin
+    - pyspark.jars
+    - pyspark.data
+    - pyspark.licenses
+    - pyspark.resource
+  requires:
+    - bash
+    - pip
+  commands:
+    - pip check
+    - bash -c "compgen -c spark && compgen -c pyspark"  # [not win]
+    - where *spark*                                     # [win]
 
 about:
-  home: http://spark.apache.org/
+  home: https://spark.apache.org/
   license: Apache-2.0
   license_family: Apache
   # Not yet available in the pypi release
-  license_file: {{ environ["RECIPE_DIR"] }}/LICENSE.txt
-  summary: Apache Spark
+  license_file: {{ environ["RECIPE_DIR"] }}/LICENSE
+  summary: Apache Spark Python API
   description: Apache Spark is a fast and general engine for large-scale data processing.
   dev_url: https://github.com/apache/spark/tree/master/python
   doc_url: https://spark.apache.org/documentation.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # pyarrow isn't available on s390x
+  skip: True  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,6 @@ test:
     - pyspark.licenses
     - pyspark.resource
   requires:
-    - bash
     - pip
   commands:
     - pip check


### PR DESCRIPTION
Requirements:
- https://github.com/apache/spark/blob/v3.2.1/python/setup.py

Actions:
1. Update `license` file
2. Remove `noarch python`
3. Skip `s390x` because of `pyarrow` isn't available
4. Update runtime pinnings
5. Update `test/imports`
6. Fix `home` url
7. Update `summary`