### PR TITLE
pyspark 3.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  # pyarrow isn't available on s390x
+  # pyarrow isn't available on s390x.
   skip: True  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 


### PR DESCRIPTION
Requirements:
- https://github.com/apache/spark/blob/v3.2.1/python/setup.py

Actions:
1. Update `license` file
2. Remove `noarch python`
3. Skip `s390x` because of `pyarrow` isn't available
4. Update runtime pinnings
5. Update `test/imports`
6. Fix `home` url
7. Update `summary`