### PR TITLE
V3.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,19 +8,14 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 72cd66ab8cf61a75854e5a753f75bea35ee075c3a96f9de4e2a66d02ec7fc652
-  patches:
-    - 0001-Disable-symlinks-on-Windows.patch
 
 build:
   number: 0
   # pyarrow isn't available on s390x.
   skip: True  # [py<38 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isoloation --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
-  build:
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # pyarrow isn't available on s390x.
-  skip: True  # [py<36 or s390x]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  # pyarrow isn't available on s390x
+  # pyarrow isn't available on s390x.
   skip: True  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ requirements:
     - wheel
   run:
     - python
-    - py4j ==0.10.9.3
+    - py4j ==0.10.9.7
     # extras_require dependencies
-    - numpy >=1.14
-    - pandas >=0.23.2
-    - pyarrow >=1.0.0
+    - numpy >=1.15
+    - pandas >=1.0.5
+    - pyarrow >=4.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   # pyarrow isn't available on s390x.
   skip: True  # [py<38 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isoloation --ignore-installed -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyspark" %}
-{% set version = "3.2.1" %}
+{% set version = "3.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0b81359262ec6e9ac78c353344e7de026027d140c6def949ff0d80ab70f89a54
+  sha256: 72cd66ab8cf61a75854e5a753f75bea35ee075c3a96f9de4e2a66d02ec7fc652
   patches:
     - 0001-Disable-symlinks-on-Windows.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   # pyarrow isn't available on s390x.
-
   skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     # extras_require dependencies
     - numpy >=1.15
     - pandas >=1.0.5
-    - pyarrow >=4.0.0
+    - pyarrow >=1.0.0
 
 test:
   imports:


### PR DESCRIPTION
[Upstream](https://github.com/apache/spark/tree/v3.4.1/python)

## Actions
- Updated version to 3.4.1
- Changed minimum `python` version to `3.8`
- Updated build script to include `--no-build-isolation`
- Dependency updates
- Removed outdated patch file `0001-Disable-symlinks-on-Windows`