### PR TITLE
Update pyspark to 4.0.1 to address CVE-2024-7254

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: 9d1f22d994f60369228397e3479003ffe2dd736ba79165003246ff7bd48e2c73
-  # get the LICENSE from the GH repo
+  # get LICENSE from the GH repo
   - url: https://raw.githubusercontent.com/apache/spark/refs/tags/v{{ version }}/LICENSE
     sha256: c2adf48f12e044a7755b0a12d6c9679b394d3e345934cd668db7c13a9eb22ff1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,12 @@ source:
     sha256: 38db1b4f6095a080d7605e578d775528990e66dc326311d93e94a71cfc24e5a5
   # get the LICENSE from the GH repo
   - url: https://raw.githubusercontent.com/apache/spark/refs/tags/v{{ version }}/LICENSE
-    sha256: 80209caf5bfbc82ad9163d9a42d7be5cbdcbf26e4e2b13666cdc11e4729ab50d
+    sha256: c2adf48f12e044a7755b0a12d6c9679b394d3e345934cd668db7c13a9eb22ff1
 
 build:
   number: 0
   # pyarrow isn't available on s390x.
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
@@ -25,14 +25,20 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.8
-    - py4j ==0.10.9.9
+    - python
+    - py4j ==0.10.9.7
+    # extras_require dependencies are kept here
+    # as runtime dependencies because previously
+    # were set as such
     - numpy >=1.21
     - pandas >=2.0.0
     - pyarrow >=11.0.0
-    - grpcio >=1.56.0
-    - grpcio-status >=1.56.0
-    - googleapis-common-protos >=1.56.4
+  run_constrained:
+    # We haven't previously included the "connect" extras, 
+    # so we can keep these in run_constrained.
+    - grpcio >=1.67.0
+    - grpcio-status >=1.67.0
+    - googleapis-common-protos >=1.65.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyspark" %}
-{% set version = "4.0.0" %}
+{% set version = "4.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 38db1b4f6095a080d7605e578d775528990e66dc326311d93e94a71cfc24e5a5
+    sha256: 9d1f22d994f60369228397e3479003ffe2dd736ba79165003246ff7bd48e2c73
   # get the LICENSE from the GH repo
   - url: https://raw.githubusercontent.com/apache/spark/refs/tags/v{{ version }}/LICENSE
     sha256: c2adf48f12e044a7755b0a12d6c9679b394d3e345934cd668db7c13a9eb22ff1
@@ -26,7 +26,7 @@ requirements:
     - wheel
   run:
     - python
-    - py4j ==0.10.9.7
+    - py4j ==0.10.9.9
     # extras_require dependencies are kept here
     # as runtime dependencies because previously
     # were set as such

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyspark" %}
-{% set version = "3.5.4" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 1c2926d63020902163f58222466adf6f8016f6c43c1f319b8e7a71dbaa05fc51
+    sha256: 38db1b4f6095a080d7605e578d775528990e66dc326311d93e94a71cfc24e5a5
   # get the LICENSE from the GH repo
   - url: https://raw.githubusercontent.com/apache/spark/refs/tags/v{{ version }}/LICENSE
     sha256: 80209caf5bfbc82ad9163d9a42d7be5cbdcbf26e4e2b13666cdc11e4729ab50d
 
 build:
-  number: 1
+  number: 0
   # pyarrow isn't available on s390x.
   skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
@@ -25,17 +25,11 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
-    - py4j ==0.10.9.7
-    # extras_require dependencies are kept here
-    # as runtime dependencies because previously
-    # were set as such
-    - numpy >=1.15,<2
-    - pandas >=1.0.5
-    - pyarrow >=4.0.0
-  run_constrained:
-    # We haven't previously included the "connect" extras, 
-    # so we can keep these in run_constrained.
+    - python >=3.8
+    - py4j ==0.10.9.9
+    - numpy >=1.21
+    - pandas >=2.0.0
+    - pyarrow >=11.0.0
     - grpcio >=1.56.0
     - grpcio-status >=1.56.0
     - googleapis-common-protos >=1.56.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - pyspark
     - pyspark.cloudpickle
     - pyspark.mllib
-    - pyspark.ml.connect
+    # pyspark.ml.connect requires optional "connect" extras (gRPC)
     - pyspark.mllib.linalg
     - pyspark.mllib.stat
     - pyspark.ml


### PR DESCRIPTION
pyspark 4.0.1 

**Destination channel:** defaults

### Links

- [PKG-9527](https://anaconda.atlassian.net/browse/PKG-9527)
- [Upstream repository](https://github.com/apache/spark)
- [Upstream changelog/diff](https://github.com/apache/spark/compare/v3.5.4...v4.0.1)

### Explanation of changes:
- Updated pyspark from 3.5.4 to 4.0.1 (major version upgrade)
- **Security fix:** Addresses CVE-2024-7254 HIGH severity vulnerability in vendored protobuf components


[PKG-9527]: https://anaconda.atlassian.net/browse/PKG-9527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ